### PR TITLE
update version of eventmachine gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source "https://rubygems.org"
 
 # gem "rails"
-
+gem 'eventmachine', '~>1.0.5'
 gem 'sinatra'
 gem 'rake'
 gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     coderay (1.1.0)
     daemons (1.1.9)
     diff-lcs (1.2.5)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     method_source (0.8.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -46,6 +46,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  eventmachine (~> 1.0.5)
   pry
   rack-test
   rake


### PR DESCRIPTION
@roseweixel: error was with the version of eventmachine gem (was 1.0.3 but need >= 1.05). Bundle install should work now. 
