### PR TITLE
Added test to check for redirect after setting user session

### DIFF
--- a/spec/sinatra_sessions_spec.rb
+++ b/spec/sinatra_sessions_spec.rb
@@ -42,6 +42,11 @@ describe 'App' do
       get '/set_session'
       expect(session[:id]).to eq(1)
     end
+
+    it "redirects user to /fetch_session_id" do
+      get '/set_session'
+      expect(last_response).to be_redirect
+    end
   end
 
   describe "GET '/fetch_session_id'" do


### PR DESCRIPTION
If you do not redirect the user to `/fetch_session_id` after setting the session id in the `/set_session` route, you will get a LintError: `Rack::Lint::LintError at /set_session. Status must be >=100 seen as integer` when visiting `/set_session`. There is no test checking to ensure that the user is redirected, so you can follow the readme, pass the tests and encounter a cryptic error message that is not mentioned.

Opened PR with a new test to check last_response.